### PR TITLE
Updated allowing of self signed certificate

### DIFF
--- a/src/discovery/discovery.py
+++ b/src/discovery/discovery.py
@@ -106,6 +106,7 @@ def find_x_satellites(ips_to_check=None, min_port=33001, max_port=33100, endpoin
                 function = check_device_type(ip, queried_port, endpoint, verbose=False)
                 # The only case we care about is when the IP and port are valid
                 if function is not None:
+                    # print(f"Found {ip}:{queried_port} with function {function}")
                     results.append({
                         "IPv4": ip,
                         "Port": queried_port,
@@ -136,6 +137,7 @@ def get_neighbouring_satellites():
     os.makedirs(directory_path, exist_ok=True)
 
     with open(file_name, "w", newline="") as csvfile:
+        # print(f"Writing to {file_name}")
         fieldnames = ["IPv4", "Port", "Contact Time", "Device Function"]
         writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
         writer.writeheader()

--- a/src/discovery/discovery.py
+++ b/src/discovery/discovery.py
@@ -7,14 +7,16 @@ import os
 import random
 import ssl
 import time
-import urllib3
 import requests  # For HTTPS requests with SSL context
 from requests.adapters import HTTPAdapter
 from urllib3.poolmanager import PoolManager
 from src.config.config import valid_functions
+
+
+import urllib3
+
 from src.helpers.send_handshake_helper import send_handshakes
 
-# Disable warnings about insecure SSL requests
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 # To block the SCSS proxying, to connect directly to the other Pis

--- a/src/discovery/discovery.py
+++ b/src/discovery/discovery.py
@@ -1,3 +1,4 @@
+# Modified by Karthees
 import argparse
 import logging
 import subprocess

--- a/src/discovery/discovery.py
+++ b/src/discovery/discovery.py
@@ -5,15 +5,7 @@ import re
 import csv
 import os
 import random
-<<<<<<< Updated upstream
-import re
-import time
-from src.config.config import valid_functions
-
-# TODO allow self signed certificates
-=======
 import ssl
->>>>>>> Stashed changes
 import urllib3
 from bobb.src.config.config import valid_functions
 
@@ -35,14 +27,9 @@ proxies = {
     'https': '',
 }
 
-<<<<<<< Updated upstream
 
 def ping_with_contact_time(ipv4, timeout=1):
     """Ping an IPv4 address and return the last contact time as a UNIX timestamp"""
-=======
-def ping_with_response_time(ipv4, timeout=1):
-    """Ping an IPv4 address and return the response time in ms."""
->>>>>>> Stashed changes
     try:
         output = subprocess.check_output(
             "ping -c 1 -W {} {}".format(timeout, ipv4),

--- a/src/helpers/send_handshake_helper.py
+++ b/src/helpers/send_handshake_helper.py
@@ -1,3 +1,4 @@
+#Modified by Karthees
 import os
 import csv
 import json

--- a/src/helpers/send_handshake_helper.py
+++ b/src/helpers/send_handshake_helper.py
@@ -2,12 +2,15 @@ import os
 import csv
 import json
 import requests
+import ssl  # For SSL context creation
+from urllib3.poolmanager import PoolManager
+from requests.adapters import HTTPAdapter
 from src.utils.headers.necessary_headers import BobbHeaders
 from src.config.constants import X_BOBB_HEADER
 from src.config.config import CONFIG_FILE_PATH
 from src.helpers.general_handshake_helper import create_handshake_message, write_received_handshake
 
-# TODO allow self signed certificates
+
 import urllib3
 urllib3.disable_warnings()
 
@@ -16,6 +19,25 @@ proxies = {
   'http': '',
   'https': '',
 }
+
+# Create an SSL context to allow self-signed certificates
+ssl_context = ssl.create_default_context()
+ssl_context.check_hostname = False
+ssl_context.verify_mode = ssl.CERT_NONE
+
+# Custom HTTPSAdapter for requests to use the above SSL context
+class SSLAdapter(HTTPAdapter):
+    def __init__(self, ssl_context=None, **kwargs):
+        self.ssl_context = ssl_context
+        super().__init__(**kwargs)
+
+    def init_poolmanager(self, *args, **kwargs):
+        kwargs['ssl_context'] = self.ssl_context
+        return super().init_poolmanager(*args, **kwargs)
+
+# Create a session to use the custom SSL context
+session = requests.Session()
+session.mount("https://", SSLAdapter(ssl_context))
 
 def send_handshakes():
     try:
@@ -29,7 +51,6 @@ def send_handshakes():
     # print(f"Known neighbours are {current_neighbours}")
     for neighbour in new_neighbours:
         send_handshake(neighbour)
-
 
 def send_handshake(neighbour):
     n_ip, n_port = neighbour
@@ -46,15 +67,15 @@ def send_handshake(neighbour):
             public_key = public_key_file.read()
             handshake_body, headers = create_handshake_message(name, function, public_key, port, ip)
 
-            # Send handshake
-            resp = requests.post(f"https://{n_ip}:{n_port}/handshake", verify=False, timeout=3, proxies=proxies, headers=headers, json=handshake_body)
+            # Send handshake using the session with custom SSL context
+            resp = session.post(f"https://{n_ip}:{n_port}/handshake", verify=False, timeout=3, proxies=proxies, headers=headers, json=handshake_body)
 
             # Deal with response from handshake - another handshake
             data = resp.json()["data"]
             bobb = BobbHeaders()
             bobb_header = bobb.parse_header(bytes.fromhex(resp.headers.get(X_BOBB_HEADER)))
             write_received_handshake(data, bobb_header)
-    
+
 def get_known_satellites():
     ip_port_pairs = []
 
@@ -95,3 +116,4 @@ def get_neighbours():
     ip_port_combinations = [(neighbor["ip"], neighbor["port"]) for neighbor in neighbors]
 
     return ip_port_combinations
+


### PR DESCRIPTION
Created an ssl_context that disables hostname checking and certificate verification, and also defined a custom SSLAdapter to integrate the ssl_context with the requests library. Configured a requests.Session to use the custom SSLAdapter for HTTPS connections and replaced requests.post with session.post to ensure the handshake requests use the custom SSL setup.